### PR TITLE
SFSW Package Test Case: init

### DIFF
--- a/.abapgit.xml
+++ b/.abapgit.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+ <asx:values>
+  <DATA>
+   <MASTER_LANGUAGE>E</MASTER_LANGUAGE>
+   <STARTING_FOLDER>/src/</STARTING_FOLDER>
+   <FOLDER_LOGIC>PREFIX</FOLDER_LOGIC>
+  </DATA>
+ </asx:values>
+</asx:abap>

--- a/src/package.devc.xml
+++ b/src/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>SFSW Package Test Case: Main package</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/sw/package.devc.xml
+++ b/src/sw/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>SFSW Package Test Case: Switch-controlled package</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zsfsw_pkg_test_sw.sfsw.xml
+++ b/src/zsfsw_pkg_test_sw.sfsw.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_SFSW" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <HEADER>
+    <SWITCH_ID>ZSFSW_PKG_TEST_SW</SWITCH_ID>
+   </HEADER>
+   <NAME32>SFSW Package Test Case: switch</NAME32>
+   <PACKAGES>
+    <SFW_DEVCL_OUTTAB_LINE>
+     <SWITCH_ID>ZSFSW_PKG_TEST_SW</SWITCH_ID>
+     <VERSION>A</VERSION>
+     <DEVCLASS>$SFSW_PKG_TC_SW</DEVCLASS>
+     <CTEXT>SFSW Package Test Case: Switch-controlled package</CTEXT>
+    </SFW_DEVCL_OUTTAB_LINE>
+   </PACKAGES>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
The test case contains an additional section in the serialized switch object xml. This new section is introduced in the fix to carry information of packages that are supposed to be managed by the switch object.